### PR TITLE
Add solid/gas species separation

### DIFF
--- a/CODE/myChemFoam/YEqn.H
+++ b/CODE/myChemFoam/YEqn.H
@@ -1,12 +1,31 @@
 {
+    // Solve solid species
     forAll(Y, specieI)
     {
-        volScalarField& Yi = Y[specieI];
+        if (isSolid[specieI])
+        {
+            volScalarField& Yi = Y[specieI];
 
-        solve
-        (
-            fvm::ddt(rho, Yi) - chemistry.RR(specieI),
-            mesh.solver("Yi")
-        );
+            solve
+            (
+                fvm::ddt(rho, Yi) - chemistry.RR(specieI),
+                mesh.solver("Yi")
+            );
+        }
+    }
+
+    // Solve gas species
+    forAll(Y, specieI)
+    {
+        if (!isSolid[specieI])
+        {
+            volScalarField& Yi = Y[specieI];
+
+            solve
+            (
+                fvm::ddt(rho, Yi) - chemistry.RR(specieI),
+                mesh.solver("Yi")
+            );
+        }
     }
 }

--- a/CODE/myChemFoam/createFields.H
+++ b/CODE/myChemFoam/createFields.H
@@ -84,3 +84,5 @@
     OFstream post(args.path()/"chemFoam.out");
     post<< "# Time" << token::TAB << "Temperature [K]" << token::TAB
         << "Pressure [Pa]" << endl;
+
+    boolList isSolid;

--- a/CODE/myChemFoam/readInitialConditions.H
+++ b/CODE/myChemFoam/readInitialConditions.H
@@ -20,6 +20,14 @@
     scalarList Y0(nSpecie, 0.0);
     scalarList X0(nSpecie, 0.0);
 
+    wordList solidSpecies;
+    if (initialConditions.found("solidSpecies"))
+    {
+        initialConditions.lookup("solidSpecies") >> solidSpecies;
+    }
+
+    isSolid.setSize(nSpecie, false);
+
     dictionary fractions(initialConditions.subDict("fractions"));
     if (fractionBasis == "mole")
     {
@@ -68,6 +76,26 @@
         forAll(Y, i)
         {
             X0[i] = Y0[i]*mw/W[i];
+        }
+    }
+
+    forAll(solidSpecies, si)
+    {
+        bool found = false;
+        forAll(Y, i)
+        {
+            if (Y[i].name() == solidSpecies[si])
+            {
+                isSolid[i] = true;
+                found = true;
+                break;
+            }
+        }
+        if (!found)
+        {
+            FatalErrorInFunction
+                << "Solid specie " << solidSpecies[si] << " not found in mixture"
+                << exit(FatalError);
         }
     }
 

--- a/CODE/myChemFoam/thermoTypeFunctions.H
+++ b/CODE/myChemFoam/thermoTypeFunctions.H
@@ -74,6 +74,14 @@ scalarList W(const rhoReactionThermo& thermo)
     {
         return W<constFluidHThermoPhysics>(thermo);
     }
+    else if (isA<reactingMixture<gasHPowerThermoPhysics>>(thermo))
+    {
+        return W<gasHPowerThermoPhysics>(thermo);
+    }
+    else if (isA<reactingMixture<constFluidHPowerThermoPhysics>>(thermo))
+    {
+        return W<constFluidHPowerThermoPhysics>(thermo);
+    }
     else
     {
         FatalErrorInFunction
@@ -101,6 +109,14 @@ scalar h0
     else if (isA<reactingMixture<constFluidHThermoPhysics>>(thermo))
     {
         return h0<constFluidHThermoPhysics>(thermo, Y, p, T);
+    }
+    else if (isA<reactingMixture<gasHPowerThermoPhysics>>(thermo))
+    {
+        return h0<gasHPowerThermoPhysics>(thermo, Y, p, T);
+    }
+    else if (isA<reactingMixture<constFluidHPowerThermoPhysics>>(thermo))
+    {
+        return h0<constFluidHPowerThermoPhysics>(thermo, Y, p, T);
     }
     else
     {

--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # Solid-gas-solver
-A modified chemFoam to include both solid and gas reactions
+A modified chemFoam to include both solid and gas reactions.
+
+The solver distinguishes between gas and solid species via a new entry
+`solidSpecies` inside `constant/initialConditions`.  The value is a word list
+of species names that are treated as solids.  Solid and gas species are solved
+separately but share the same temperature field.  The solver now supports
+hPower-based thermodynamic data via additional type handling in
+`thermoTypeFunctions.H`.


### PR DESCRIPTION
## Summary
- add a bool list to mark solid species
- read `solidSpecies` from `initialConditions`
- solve solid and gas species separately
- document new behaviour in README
- support `hPower` thermodynamic data in `thermoTypeFunctions.H`

## Testing
- `wmake` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68625fb8ed948333bf3583e29b1df93a